### PR TITLE
add parallel sequences as an object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ Parameterize Jobs
 Features
 --------
 
-* Expand a job's dimensionality by multiplying ``ComponentSet``, ``Constant``, or ``ParallelSequenceSet`` objects
-* Extend the number of jobs by adding ``ComponentSet``, ``Constant``, or ``ParallelSequenceSet`` objects
+* Expand a job's dimensionality by multiplying ``ComponentSet``, ``Constant``, or ``ParallelComponentSet`` objects
+* Extend the number of jobs by adding ``ComponentSet``, ``Constant``, or ``ParallelComponentSet`` objects
 * Jobs are provided to functions as dictionaries of parameters
 * The helper decorator ``@expand_kwargs`` turns these kwarg dictionaries into
   named argument calls
@@ -152,14 +152,14 @@ A ``Constant`` object is simply a ``ComponentSet`` object defined with single va
     >>> list(map(my_simple_func, (ab1 + ab2) * c))
     [0, 0, 0, 5, -50, -55, 50, 55]
 
-A ``ParallelSequenceSet`` object is simply a ``MultiComponentSet`` object where each ``Component`` is a ``Constant`` object.
+A ``ParallelComponentSet`` object is simply a ``MultiComponentSet`` object where each ``Component`` is a ``Constant`` object.
 
 .. code-block:: python
 
-    >>> pss = pjs.ParallelSequenceSet(a = [1, 2],
+    >>> pcs = pjs.ParallelComponentSet(a = [1, 2],
                                b = [10, 20])
 
-    >>> list(map(my_simple_func, pss))
+    >>> list(map(my_simple_func, pcs))
     [10, 40]
 
 Arbitrarily complex combinations of ComponentSets can be created:

--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,8 @@ Parameterize Jobs
 Features
 --------
 
-* Expand a job's dimensionality by multiplying ``ComponentSet`` or ``Constant`` objects
-* Extend the number of jobs by adding ``ComponentSet`` or ``Constant`` objects
+* Expand a job's dimensionality by multiplying ``ComponentSet``, ``Constant``, or ``ParallelSequenceSet`` objects
+* Extend the number of jobs by adding ``ComponentSet``, ``Constant``, or ``ParallelSequenceSet`` objects
 * Jobs are provided to functions as dictionaries of parameters
 * The helper decorator ``@expand_kwargs`` turns these kwarg dictionaries into
   named argument calls
@@ -151,6 +151,16 @@ A ``Constant`` object is simply a ``ComponentSet`` object defined with single va
 
     >>> list(map(my_simple_func, (ab1 + ab2) * c))
     [0, 0, 0, 5, -50, -55, 50, 55]
+
+A ``ParallelSequenceSet`` object is simply a ``MultiComponentSet`` object where each ``Component`` is a ``Constant`` object.
+
+.. code-block:: python
+
+    >>> pss = pjs.ParallelSequenceSet(a = [1, 2],
+                               b = [10, 20])
+
+    >>> list(map(my_simple_func, pss))
+    [10, 40]
 
 Arbitrarily complex combinations of ComponentSets can be created:
 

--- a/parameterize_jobs/__init__.py
+++ b/parameterize_jobs/__init__.py
@@ -9,7 +9,7 @@ from parameterize_jobs.parameterize_jobs import (
     ComponentSet,
     MultiComponentSet,
     Constant,
-    ParallelSequenceSet,
+    ParallelComponentSet,
     expand_kwargs)
 
 __author__ = """Michael Delgado"""
@@ -21,7 +21,7 @@ _module_imports = (
     ComponentSet,
     MultiComponentSet,
     Constant,
-    ParallelSequenceSet,
+    ParallelComponentSet,
     expand_kwargs
 )
 

--- a/parameterize_jobs/__init__.py
+++ b/parameterize_jobs/__init__.py
@@ -9,6 +9,7 @@ from parameterize_jobs.parameterize_jobs import (
     ComponentSet,
     MultiComponentSet,
     Constant,
+    ParallelSequenceSet,
     expand_kwargs)
 
 __author__ = """Michael Delgado"""
@@ -20,6 +21,7 @@ _module_imports = (
     ComponentSet,
     MultiComponentSet,
     Constant,
+    ParallelSequenceSet,
     expand_kwargs
 )
 

--- a/parameterize_jobs/parameterize_jobs.py
+++ b/parameterize_jobs/parameterize_jobs.py
@@ -184,7 +184,7 @@ class Constant(ComponentSet):
             (k, Component([v])) for k, v in kwargs.items()])
 
 
-class ParallelSequenceSet(MultiComponentSet):
+class ParallelComponentSet(MultiComponentSet):
     '''
     A MultiComponentSet object created by multiple lists of 
     the same length, where each job will take the nth element

--- a/parameterize_jobs/parameterize_jobs.py
+++ b/parameterize_jobs/parameterize_jobs.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 import itertools
 import functools
-from collections import OrderedDict, Sequence
+from collections import OrderedDict
 
 import parameterize_jobs._compat as _compat
 from parameterize_jobs._utils import _product, _cumprod
@@ -186,19 +186,20 @@ class Constant(ComponentSet):
 
 class ParallelComponentSet(MultiComponentSet):
     '''
-    A MultiComponentSet object created by multiple lists of 
+    A MultiComponentSet object created by multiple lists of
     the same length, where each job will take the nth element
     of each list
     '''
     def __init__(self, **kwargs):
         lengths = [len(v) for v in kwargs.values()]
-        if len(set(lengths))!=1:
+        if len(set(lengths)) != 1:
             raise ValueError('Passed values are not lists of equal length.')
         param_length = lengths[0]
-        
-        self._components = [Constant(**{k: v[vx] for k,v in kwargs.items()}) for vx in range(param_length)]
-        
-        
+
+        self._components = [Constant(**{k: v[vx] for k, v in kwargs.items()})
+                            for vx in range(param_length)]
+
+
 def expand_kwargs(func):
     '''
     Decorator to expand an kwargs in function calls

--- a/parameterize_jobs/parameterize_jobs.py
+++ b/parameterize_jobs/parameterize_jobs.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 import itertools
 import functools
-from collections import OrderedDict
+from collections import OrderedDict, Sequence
 
 import parameterize_jobs._compat as _compat
 from parameterize_jobs._utils import _product, _cumprod
@@ -184,6 +184,21 @@ class Constant(ComponentSet):
             (k, Component([v])) for k, v in kwargs.items()])
 
 
+class ParallelSequenceSet(MultiComponentSet):
+    '''
+    A MultiComponentSet object created by multiple lists of 
+    the same length, where each job will take the nth element
+    of each list
+    '''
+    def __init__(self, **kwargs):
+        lengths = [len(v) for v in kwargs.values()]
+        if len(set(lengths))!=1:
+            raise ValueError('Passed values are not lists of equal length.')
+        param_length = lengths[0]
+        
+        self._components = [Constant(**{k: v[vx] for k,v in kwargs.items()}) for vx in range(param_length)]
+        
+        
 def expand_kwargs(func):
     '''
     Decorator to expand an kwargs in function calls

--- a/tests/test_parameterize_jobs.py
+++ b/tests/test_parameterize_jobs.py
@@ -63,17 +63,19 @@ def sample_py_nd_componentset():
             range10=range(10)),
         (10, 10))
 
+
 @pytest.fixture
 def sample_py_parallelcomponentset():
     '''
-    get a (ParallelComponentSet, shape) tuple 
+    get a (ParallelComponentSet, shape) tuple
     for a ComponentSet with multiple builtins
     '''
     return (
         pj.ParallelComponentSet(
-            pcs1=range(0,10),
-            pcs2=range(20,30)),
+            pcs1=range(0, 10),
+            pcs2=range(20, 30)),
         (10, ))
+
 
 @pytest.fixture
 def sample_numpy_componentset():
@@ -107,6 +109,7 @@ def sample_numpy_nd_componentset():
             sin=np.sin(np.linspace(0, 2*np.pi, 100))),
         (10, 10, 100))
 
+
 @pytest.fixture
 def sample_numpy_parallelcomponentset():
     '''
@@ -115,8 +118,8 @@ def sample_numpy_parallelcomponentset():
     '''
     return (
         pj.ParallelComponentSet(
-            pcs1=np.arange(0,10),
-            pcs2=np.arange(20,30)),
+            pcs1=np.arange(0, 10),
+            pcs2=np.arange(20, 30)),
         (10, ))
 
 
@@ -217,7 +220,8 @@ def test_complex_componentsets(
 
     cplx = ((cs1 + cs2) * cons1 + cons2 * (cs1 + cs2)) * pcs
 
-    assert len(cplx) == 2 * (_product(shape1) + _product(shape2)) * _product(shape3)
+    assert len(cplx) == 2 * (_product(shape1) +
+                             _product(shape2)) * _product(shape3)
 
     assert cplx[1] == merge_dicts(cs1[1], cons1[0], pcs[0])
     assert cplx[len(cs1) + 1] == merge_dicts(cs1[1], cons1[0], pcs[1])
@@ -231,15 +235,18 @@ def test_complex_componentsets(
 def test_numpy_componentset(sample_numpy_componentset):
     test_componentset(sample_numpy_componentset)
 
+
 @requires_numpy
 def test_numpy_ndcomponentset(sample_numpy_nd_componentset):
     test_ndcomponentset(sample_numpy_nd_componentset)
+
 
 @requires_numpy
 def test_numpy_multiple_componentsets(
         sample_numpy_componentset, another_numpy_componentset):
     test_multiple_componentsets(
         sample_numpy_componentset, another_numpy_componentset)
+
 
 @requires_numpy
 def test_numpy_complex_componentsets(

--- a/tests/test_parameterize_jobs.py
+++ b/tests/test_parameterize_jobs.py
@@ -63,6 +63,17 @@ def sample_py_nd_componentset():
             range10=range(10)),
         (10, 10))
 
+@pytest.fixture
+def sample_py_parallelcomponentset():
+    '''
+    get a (ParallelComponentSet, shape) tuple 
+    for a ComponentSet with multiple builtins
+    '''
+    return (
+        pj.ParallelComponentSet(
+            pcs1=range(0,10),
+            pcs2=range(20,30)),
+        (10, ))
 
 @pytest.fixture
 def sample_numpy_componentset():
@@ -95,6 +106,18 @@ def sample_numpy_nd_componentset():
             fib10=np.array([0, 1, 1, 2, 3, 5, 8, 13, 21, 34]),
             sin=np.sin(np.linspace(0, 2*np.pi, 100))),
         (10, 10, 100))
+
+@pytest.fixture
+def sample_numpy_parallelcomponentset():
+    '''
+    get a (ParallelComponentSet, shape) tuple
+    for a ComponentSet with multiple builtins
+    '''
+    return (
+        pj.ParallelComponentSet(
+            pcs1=np.arange(0,10),
+            pcs2=np.arange(20,30)),
+        (10, ))
 
 
 def test_constant(sample_py_constant):
@@ -154,7 +177,7 @@ def test_ndcomponentset(sample_py_nd_componentset):
         cs * cs  # cannot multiply ComponentSets by themselves
 
 
-def test_py_multiple_componentsets(
+def test_multiple_componentsets(
         sample_py_componentset, another_py_componentset):
 
     cs1, shape1 = sample_py_componentset
@@ -183,20 +206,22 @@ def test_complex_componentsets(
         sample_py_constant,
         another_py_constant,
         sample_py_componentset,
-        another_py_componentset):
+        another_py_componentset,
+        sample_py_parallelcomponentset):
 
     cons1, _ = sample_py_constant
     cons2, _ = another_py_constant
     cs1, shape1 = sample_py_componentset
     cs2, shape2 = another_py_componentset
+    pcs, shape3 = sample_py_parallelcomponentset
 
-    cplx = (cs1 + cs2) * cons1 + cons2 * (cs1 + cs2)
+    cplx = ((cs1 + cs2) * cons1 + cons2 * (cs1 + cs2)) * pcs
 
-    assert len(cplx) == 2 * (_product(shape1) + _product(shape2))
+    assert len(cplx) == 2 * (_product(shape1) + _product(shape2)) * _product(shape3)
 
-    assert cplx[1] == merge_dicts(cs1[1], cons1[0])
-    assert cplx[len(cs1) + 1] == merge_dicts(cs2[1], cons1[0])
-    assert cplx[-1] == merge_dicts(cs2[-1], cons2[0])
+    assert cplx[1] == merge_dicts(cs1[1], cons1[0], pcs[0])
+    assert cplx[len(cs1) + 1] == merge_dicts(cs1[1], cons1[0], pcs[1])
+    assert cplx[-1] == merge_dicts(cs2[-1], cons2[0], pcs[-1])
 
     full_cplx = list(cplx)
     assert len(full_cplx) == len(cplx)
@@ -204,99 +229,31 @@ def test_complex_componentsets(
 
 @requires_numpy
 def test_numpy_componentset(sample_numpy_componentset):
-    cs, shape = sample_numpy_componentset
-
-    assert len(cs) == shape[0]
-    assert len(cs[0]) == 1
-    assert len(cs) == len(list(cs))
-    assert cs[0] == cs[-len(cs)]
-
-    # requires sample_py_componentset to have unique first and last elements
-    assert cs[0] != cs[-1]
-
-    with pytest.raises(KeyError):
-        cs[shape[0]]
-
-    with pytest.raises(KeyError):
-        cs[-shape[0] - 1]
-
-    assert len(cs + cs) == shape[0] * 2
-
-    with pytest.raises(TypeError):
-        cs * cs  # cannot multiply ComponentSets by themselves
-
+    test_componentset(sample_numpy_componentset)
 
 @requires_numpy
 def test_numpy_ndcomponentset(sample_numpy_nd_componentset):
-    cs, shape = sample_numpy_nd_componentset
-
-    assert len(cs) == _product(shape)
-    assert len(cs[0]) == len(shape)
-    assert cs[0] == cs[-len(cs)]
-
-    # requires sample_py_componentset to have unique first and last elements
-    assert cs[0] != cs[-1]
-
-    with pytest.raises(KeyError):
-        cs[_product(shape)]
-
-    with pytest.raises(KeyError):
-        cs[-_product(shape) - 1]
-
-    assert len(cs + cs) == _product(shape) * 2
-
-    with pytest.raises(TypeError):
-        cs * cs  # cannot multiply ComponentSets by themselves
-
+    test_ndcomponentset(sample_numpy_nd_componentset)
 
 @requires_numpy
 def test_numpy_multiple_componentsets(
         sample_numpy_componentset, another_numpy_componentset):
-
-    cs1, shape1 = sample_numpy_componentset
-    cs2, shape2 = another_numpy_componentset
-
-    assert len(cs1 + cs2) == len(cs1) + len(cs2)
-    assert len(cs1 + cs2) == _product(shape1) + _product(shape2)
-
-    assert len(cs1 * cs2) == len(cs1) * len(cs2)
-    assert len(list(cs1 * cs2)) == len(cs1 * cs2)
-
-    assert (cs1 + cs2)[0] == cs1[0]
-    assert (cs1 + cs2)[1] == cs1[1]
-    assert (cs1 + cs2)[-2] == cs2[-2]
-    assert (cs1 + cs2)[-1] == cs2[-1]
-
-    assert (cs1 * cs2)[0] == merge_dicts(cs1[0], cs2[0])
-    assert (cs1 * cs2)[-1] == merge_dicts(cs1[-1], cs2[-1])
-
-    full_product = list(cs1 * cs2)
-    assert full_product[0] == (cs1 * cs2)[0]
-    assert full_product[-1] == (cs1 * cs2)[-1]
-
+    test_multiple_componentsets(
+        sample_numpy_componentset, another_numpy_componentset)
 
 @requires_numpy
 def test_numpy_complex_componentsets(
         sample_py_constant,
         another_py_constant,
         sample_numpy_componentset,
-        another_numpy_componentset):
-
-    cons1, _ = sample_py_constant
-    cons2, _ = another_py_constant
-    cs1, shape1 = sample_numpy_componentset
-    cs2, shape2 = another_numpy_componentset
-
-    cplx = (cs1 + cs2) * cons1 + cons2 * (cs1 + cs2)
-
-    assert len(cplx) == 2 * (_product(shape1) + _product(shape2))
-
-    assert cplx[1] == merge_dicts(cs1[1], cons1[0])
-    assert cplx[len(cs1) + 1] == merge_dicts(cs2[1], cons1[0])
-    assert cplx[-1] == merge_dicts(cs2[-1], cons2[0])
-
-    full_cplx = list(cplx)
-    assert len(full_cplx) == len(cplx)
+        another_numpy_componentset,
+        sample_numpy_parallelcomponentset):
+    test_complex_componentsets(
+        sample_py_constant,
+        another_py_constant,
+        sample_numpy_componentset,
+        another_numpy_componentset,
+        sample_numpy_parallelcomponentset)
 
 
 def test_reprs(


### PR DESCRIPTION
 - [x] closes #80 
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 parameterize_jobs tests docs``
 - [ ] entry in HISTORY.rst

Added a new object ``ParallelComponentSet`` to allow a common use case where you have multiple Sequences that should be used by jobs in parallel (i.e. job N should pull the Nth element of each sequence).

Also cleaned up numpy tests a bit by just passing arrays to the same raw python tests.