### PR TITLE
Add basic GH action workflow to install pkg, run pytest

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -1,0 +1,37 @@
+name: Python package
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.x"]
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'requirements-dev.txt'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-dev.txt
+      - name: Install package
+        run: |
+          pip install .
+      - name: Format check with flake8
+        run: |
+          flake8
+      - name: Test with pytest
+        run: |
+          pytest -v --cov parameterize_jobs --cov-report term-missing --cov-report xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
Adds basic python package install and testing using Github Actions. We need this so we can get automated testing back online as we recover from Travis CI.

Part of #107 