### PR TITLE
Minor fixes to pass new CI test runs

### DIFF
--- a/parameterize_jobs/parameterize_jobs.py
+++ b/parameterize_jobs/parameterize_jobs.py
@@ -45,10 +45,10 @@ class ComponentSet(object):
 
     def __getitem__(self, idx):
         if isinstance(idx, dict):
-            raise NotImplemented('dictionary indexing not yet supported')
+            raise NotImplementedError('dictionary indexing not yet supported')
 
         elif isinstance(idx, slice):
-            raise NotImplemented('slice indexing not yet supported')
+            raise NotImplementedError('slice indexing not yet supported')
 
         elif isinstance(idx, int):
 
@@ -70,7 +70,7 @@ class ComponentSet(object):
                 for i, k in enumerate(self._sets.keys())}
 
         else:
-            raise NotImplemented(
+            raise NotImplementedError(
                 '{} indexing not yet supported'.format(type(idx)))
 
     def __len__(self):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,6 @@ tox==3.14.0
 coverage==4.5.4
 coveralls==1.8.2
 Sphinx==1.8.3
-pytest==4.4.1
+pytest>=6.5.2
 pytest-cov==2.7.1
 pytest-runner==5.1


### PR DESCRIPTION
Fixes a few old, nagging bugs:
* Fixes error flake8 catches in CI because the code is raising `NotImplemented` instead of `NotImplementedError`. Here is [one example](https://github.com/ClimateImpactLab/parameterize_jobs/runs/6929222789).
* Updates pytest, fixing an error in how it handles newer python3 assertions.