### PR TITLE
Update README badges for new CI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,16 +5,15 @@ Parameterize Jobs
 .. image:: https://img.shields.io/pypi/v/parameterize_jobs.svg
         :target: https://pypi.python.org/pypi/parameterize_jobs
 
-.. image:: https://img.shields.io/travis/ClimateImpactLab/parameterize_jobs.svg
-        :target: https://travis-ci.org/ClimateImpactLab/parameterize_jobs
+.. image:: https://github.com/ClimateImpactLab/parameterize_jobs/actions/workflows/pythonpackage.yaml/badge.svg
+        :target: https://github.com/ClimateImpactLab/parameterize_jobs/actions/workflows/pythonpackage.yaml
+
+.. image:: https://codecov.io/gh/ClimateImpactLab/parameterize_jobs/branch/master/graph/badge.svg?token=DUDCDOPYYC
+        :target: https://codecov.io/gh/ClimateImpactLab/parameterize_jobs
 
 .. image:: https://readthedocs.org/projects/parameterize-jobs/badge/?version=latest
         :target: https://parameterize-jobs.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
-
-.. image:: https://pyup.io/repos/github/ClimateImpactLab/parameterize_jobs/shield.svg
-     :target: https://pyup.io/repos/github/ClimateImpactLab/parameterize_jobs/
-     :alt: Updates
 
 ``parameterize_jobs`` is a lightweight, pure-python toolkit for concisely and clearly creating large, parameterized, mapped job specifications.
 


### PR DESCRIPTION
Updates the badges in the README to use the new CI additions. Some of the old badges are broken.

In short:
- Swap Travis CI for gh-actions tests badge
- Add codecov badge — shows test coverage.
- Drop the pyup.io badge. Seemed broken and dependabot fills its niche role.

Part of #107.