### PR TITLE
Fix missing __version__ attr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.ruff_cache/
 
 # Translations
 *.mo
@@ -61,6 +62,7 @@ target/
 # pyenv python configuration file
 .python-version
 
-
 # pytest cache
 .pytest_cache
+
+src/parameterize_jobs/_version.py

--- a/src/parameterize_jobs/__init__.py
+++ b/src/parameterize_jobs/__init__.py
@@ -1,7 +1,7 @@
 
 """Top-level package for Parameterize Jobs."""
 
-
+from parameterize_jobs._version import version as __version__
 from parameterize_jobs.parameterize_jobs import (
     Component,
     ComponentSet,

--- a/src/parameterize_jobs/__init__.py
+++ b/src/parameterize_jobs/__init__.py
@@ -1,7 +1,7 @@
 
 """Top-level package for Parameterize Jobs."""
 
-from parameterize_jobs._version import version as __version__
+from parameterize_jobs._version import version
 from parameterize_jobs.parameterize_jobs import (
     Component,
     ComponentSet,
@@ -12,6 +12,7 @@ from parameterize_jobs.parameterize_jobs import (
 
 __author__ = """Michael Delgado"""
 __email__ = 'delgado.michaelt@gmail.com'
+__version__ = version
 
 _module_imports = (
     Component,


### PR DESCRIPTION
Users used to be able to get the package version like

```
import parameterize_jobs

parameterize_jobs.__version__
```

but this no longer works.

This PR fixes the problem by importing `__version__` from the `_version.py` file created when the package is built/installed.