### PR TITLE
Ruff refresh

### DIFF
--- a/.github/workflows/pythonpackage.yaml
+++ b/.github/workflows/pythonpackage.yaml
@@ -34,7 +34,7 @@ jobs:
           pip install -r requirements.txt
       - name: Format check with ruff
         run: |
-          ruff check .
+          ruff check . --diff
 
   test:
     runs-on: ubuntu-latest

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 Unreleased
 ----------
 
-*
+* Minor code format cleanup, ruff config update.
 
 
 0.2.0 (2023-09-01)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ exclude = [
     ".eggs",
     "docs",
 ]
+
+[tool.ruff.lint]
 # E402: module level import not at top of file
 ignore = [
     "E402",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 numpy==1.26.4
 pytest==8.1.1
 pytest-cov==5.0.0
-ruff==0.3.0
+ruff==0.3.5

--- a/src/parameterize_jobs/parameterize_jobs.py
+++ b/src/parameterize_jobs/parameterize_jobs.py
@@ -50,9 +50,10 @@ class ComponentSet:
         elif isinstance(idx, int):
 
             if (idx >= len(self)) or (idx < -1 * len(self)):
+                name = self.__class__.__name__
+                n = len(self)
                 raise KeyError(
-                    'index {} out of bounds for {} with length {}'
-                    .format(idx, self.__class__.__name__, len(self)))
+                    f'index {idx} out of bounds for {name} with length {n}')
 
             lens = list(map(len, self._sets.values()))
             cplens = list(_cumprod(list(
@@ -137,9 +138,10 @@ class MultiComponentSet:
 
     def __getitem__(self, idx):
         if (idx >= len(self)) or (idx < -1 * len(self)):
+            name = self.__class__.__name__
+            n = len(self)
             raise KeyError(
-                'index {} out of bounds for {} with length {}'
-                .format(idx, self.__class__.__name__, len(self)))
+                f'index {idx} out of bounds for {name} with length {n}')
 
         idx = idx % len(self)
 


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``ruff check .``
 - [x] entry in HISTORY.rst

Minor update to ruff config to remove deprecated setup. Make ruff checks in CI more verbose. Minor code cleanup for ruff update to v0.3.5.